### PR TITLE
Fix CMake Build Errors

### DIFF
--- a/libsoundio-sys/build.rs
+++ b/libsoundio-sys/build.rs
@@ -91,6 +91,7 @@ fn main() {
         .define("BUILD_STATIC_LIBS", "ON")
         .define("BUILD_EXAMPLE_PROGRAMS", "OFF")
         .define("BUILD_TESTS", "OFF")
+        .define("CMAKE_POLICY_VERSION_MINIMUM", "3.5")
         .build();
 
     println!(


### PR DESCRIPTION
CMake 4 broke stuff, at least this allows the project to compile again